### PR TITLE
[FEAT]: 온보딩 첫 진입 시 애니메이션 1회만 실행되도록 sessionStorage 플래그 적용

### DIFF
--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -16,8 +16,7 @@ const animationProps = {
 export default function MainPage() {
   const router = useRouter();
 
-  const [isMounted, setIsMounted] = useState<boolean>(false);
-  const [isFirstVisit, setIsFirstVisit] = useState<boolean>(false);
+  const [isFirstVisit, setIsFirstVisit] = useState<boolean | null>(null);
 
   useEffect(() => {
     const visited = sessionStorage.getItem('isVisitedMain');
@@ -25,14 +24,10 @@ export default function MainPage() {
     if (!visited) {
       setIsFirstVisit(true);
       sessionStorage.setItem('isVisitedMain', 'true');
-    }
-
-    setIsMounted(true);
+    } else setIsFirstVisit(false);
   }, []);
 
-  if (!isMounted) {
-    return null;
-  }
+  if (isFirstVisit === null) return null;
 
   const conditionalProps = isFirstVisit ? animationProps : {};
 


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
#40 
<br><br>

## What is this PR? 🔍
메인 페이지 온보딩 애니메이션이 세션당 한 번만 실행되도록 로직을 구현했습니다.
사용자가 현재 세션 내에서 메인 페이지를 이전에 방문했는지 여부를 추적하기 위해 sessionStorage를 활용했으니 이미지 참고해 주세요!

<!-- 작업 내용을 설명해 주세요 -->

<br><br>

## Screenshot 📷

<!-- 구현된 기능/디자인 gif -->

<img width="1088" height="396" alt="image" src="https://github.com/user-attachments/assets/1f8d83c6-ed5a-416a-8573-fbe3faf2ea70" />

