### PR TITLE
[FEAT]: 공모전 상세 페이지에 공모분야 카테고리 추가 및 기관, 시상 통합

### DIFF
--- a/src/app/contest/[id]/_components/ContestDetailMeta.tsx
+++ b/src/app/contest/[id]/_components/ContestDetailMeta.tsx
@@ -36,8 +36,8 @@ export const ContestDetailMeta = ({
       ) : (
         <DefaultImage className='h-[519px] w-[430px] rounded-sm' />
       )}
-      <section className='flex w-full flex-col gap-9'>
-        <div className='absolute top-6 right-9 flex flex-row items-center gap-6'>
+      <section className='flex w-full flex-col justify-center gap-9'>
+        <div className='absolute top-15 right-9 flex flex-row items-center gap-6'>
           <button onClick={onShare} aria-label='공유 버튼'>
             <Share />
           </button>
@@ -45,7 +45,6 @@ export const ContestDetailMeta = ({
             {contest.bookmarked ? <FilledLikeIcon /> : <LikeIcon />}
           </button>
         </div>
-
         <div className='flex flex-col gap-4'>
           <h2 className='text-2xl font-bold'>접수 기간</h2>
           <div className='flex flex-row items-center gap-[75px]'>
@@ -56,19 +55,18 @@ export const ContestDetailMeta = ({
             </h3>
           </div>
         </div>
-
         <div className='flex flex-col gap-4'>
-          <h2 className='text-2xl font-bold'>기관</h2>
+          <h2 className='text-2xl font-bold'>공모분야</h2>
+          <p className='text-xl font-normal'>{contest.category}</p>
+        </div>
+        <div className='flex flex-col gap-4'>
+          <h2 className='text-2xl font-bold'>기관/시상</h2>
           <div className='flex flex-row gap-[138px] text-xl font-normal'>
             <p>주최</p>
             <p>{contest.host}</p>
           </div>
-        </div>
-
-        <div className='flex flex-col gap-4'>
-          <h2 className='text-2xl font-bold'>시상</h2>
           <div className='flex flex-row gap-[120px] text-xl font-normal'>
-            <p>시상금</p>
+            <p>시상규모</p>
             <p>{contest.reward}</p>
           </div>
         </div>


### PR DESCRIPTION
## ISSUE 🔗

<!-- ex) close #이슈번호 -->
close #112 
<br><br>

## What is this PR? 🔍

<!-- 작업 내용을 설명해 주세요 -->
바뀐 피그마 디자인에 따라 공모전 상세 페이지에 카테고리를 렌더링하는 섹션을 추가했습니다. 
기관/시상 부분도 통합하여 하나의 섹션에서 렌더링합니다. 

<img width="619" height="428" alt="image" src="https://github.com/user-attachments/assets/c07c36d3-087c-4996-8bd2-3978827fafdd" />


<br><br>

## Test Checklist ✔

<!-- 어떤 내용을 테스트했는지/해야 하는지 -->

- [ ] 피그마와 일치하는지
